### PR TITLE
Modified: Mangadex API call for chapters

### DIFF
--- a/src/app/services/MangadexAPI.js
+++ b/src/app/services/MangadexAPI.js
@@ -1,13 +1,13 @@
 import axios from "axios";
 // todo: move this to a config/appConfig.js
 const APP_CONFIG = {
-  apiUrl: "https://api.mangadex.org/"
+  apiUrl: "https://api.mangadex.org/",
 };
 
 class MangadexAPI {
   constructor() {
     this.api = axios.create({
-      baseURL: APP_CONFIG.apiUrl
+      baseURL: APP_CONFIG.apiUrl,
     });
   }
 
@@ -35,7 +35,7 @@ class MangadexAPI {
   }
   async fetchChapter(seriesId) {
     const response = await this.api.get(
-      `manga/${seriesId}/feed?translatedLanguage[]=en&order[volume]=desc`
+      `manga/${seriesId}/feed?translatedLanguage[]=en&order[chapter]=desc`
     );
 
     return response.data;
@@ -49,13 +49,13 @@ class MangadexAPI {
     return data;
   }
 
-   async fetchAuthor(authorID) {
+  async fetchAuthor(authorID) {
     const requestURL = `http://localhost:3001?query=author&ID=${authorID}`;
 
     console.log(authorID);
     console.log(requestURL);
 
-    return fetch(requestURL, { method: "GET" }).then(response =>
+    return fetch(requestURL, { method: "GET" }).then((response) =>
       response.json()
     );
     //console.log(response)


### PR DESCRIPTION
The reason for the chapters not being descending as specified was for the dumbest reason possible. The URL that was previously used (using Frieren's ID as an example) was: 

"https://api.mangadex.org/manga/b0b721ff-c388-4486-aa0f-c2b0bb321512/feed?translatedLanguage[]=en&order[volume]=desc"

with the query parameter used to specify the way to order it being at the end. As you can see.... this is ordering the chapters by volume. This is not at all what is needed by the application, so this was easily fixed to be:

"https://api.mangadex.org/manga/b0b721ff-c388-4486-aa0f-c2b0bb321512/feed?translatedLanguage[]=en&order[chapter]=desc"

Much better.